### PR TITLE
Only logging "Client will now throw an _MqttConnectingFailedException_." warning when actually throwing the exception

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,4 +1,5 @@
 * [Client] Fixed _PlatformNotSupportedException_ when using Blazor (#1755, thanks to @Nickztar).
+* [Client] Fixed wrong logging of obsolete feature when connection was not successful (#1801, thanks to @ramonsmits).
 * [Server] Fixed _NullReferenceException_ in retained messages management (#1762, thanks to @logicaloud).
 * [Server] Exposed new option which allows disabling packet fragmentation (#1753).
 * [Server] Expired sessions will no longer be used when a client connects (#1756).

--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -3,3 +3,4 @@
 * [Server] Fixed _NullReferenceException_ in retained messages management (#1762, thanks to @logicaloud).
 * [Server] Exposed new option which allows disabling packet fragmentation (#1753).
 * [Server] Expired sessions will no longer be used when a client connects (#1756).
+* [Server] Fixed an issue in connection handling for ASP.NET connections (#1819, thanks to @CZEMacLeod).

--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,4 +1,5 @@
 * [Client] Fixed _PlatformNotSupportedException_ when using Blazor (#1755, thanks to @Nickztar).
+* [Client] Fixed _NullReferenceException_ when performing several actions when not connected (#1800, thanks to @ramonsmits).
 * [Server] Fixed _NullReferenceException_ in retained messages management (#1762, thanks to @logicaloud).
 * [Server] Exposed new option which allows disabling packet fragmentation (#1753).
 * [Server] Expired sessions will no longer be used when a client connects (#1756).

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -33,8 +33,11 @@ namespace MQTTnet.AspNetCore
             PacketFormatterAdapter = packetFormatterAdapter ?? throw new ArgumentNullException(nameof(packetFormatterAdapter));
             _connection = connection ?? throw new ArgumentNullException(nameof(connection));
 
-            _input = connection.Transport.Input;
-            _output = connection.Transport.Output;
+            if (!(_connection is TcpConnection tcp) || tcp.IsConnected)
+            {
+                _input = connection.Transport.Input;
+                _output = connection.Transport.Output;
+            }
         }
 
         public long BytesReceived { get; private set; }

--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Connection_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Connection_Tests.cs
@@ -196,5 +196,27 @@ namespace MQTTnet.Tests.Clients.MqttClient
                 Assert.AreEqual(response.UserProperties[0].Value, "Value");
             }
         }
+
+        [TestMethod]
+        public async Task Throw_Proper_Exception_When_Not_Connected()
+        {
+            try
+            {
+                var mqttFactory = new MqttFactory();
+                using (var mqttClient = mqttFactory.CreateMqttClient())
+                {
+                    await mqttClient.SubscribeAsync("test", MqttQualityOfServiceLevel.AtLeastOnce);
+                }
+            }
+            catch (MqttCommunicationException exception)
+            {
+                if (exception.Message == "The client is not connected.")
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail();
+        }
     }
 }

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -465,11 +465,10 @@ namespace MQTTnet.Client
             // did send a proper ACK packet with a non success response.
             if (options.ThrowOnNonSuccessfulConnectResponse)
             {
-                _logger.Warning(
-                    "Client will now throw an _MqttConnectingFailedException_. This is obsolete and will be removed in the future. Consider setting _ThrowOnNonSuccessfulResponseFromServer=False_ in client options.");
-
                 if (result.ResultCode != MqttClientConnectResultCode.Success)
                 {
+                    _logger.Warning(
+                        "Client will now throw an _MqttConnectingFailedException_. This is obsolete and will be removed in the future. Consider setting _ThrowOnNonSuccessfulResponseFromServer=False_ in client options.");
                     throw new MqttConnectingFailedException($"Connecting with MQTT server failed ({result.ResultCode}).", null, result);
                 }
             }

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -321,13 +321,13 @@ namespace MQTTnet.Client
                 MqttTopicValidator.ThrowIfInvalidSubscribe(topicFilter.Topic);
             }
 
+            ThrowIfDisposed();
+            ThrowIfNotConnected();
+            
             if (Options.ValidateFeatures)
             {
                 MqttClientSubscribeOptionsValidator.ThrowIfNotSupported(options, _adapter.PacketFormatterAdapter.ProtocolVersion);
             }
-
-            ThrowIfDisposed();
-            ThrowIfNotConnected();
 
             var subscribePacket = MqttPacketFactories.Subscribe.Create(options);
             subscribePacket.PacketIdentifier = _packetIdentifierProvider.GetNextPacketIdentifier();

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -478,6 +478,12 @@ namespace MQTTnet.Client
             return this;
         }
 
+        public MqttClientOptionsBuilder WithWillMessageExpiryInterval(uint willMessageExpiryInterval)
+        {
+            _options.WillMessageExpiryInterval = willMessageExpiryInterval;
+            return this;
+        }
+
         public MqttClientOptionsBuilder WithWillTopic(string willTopic)
         {
             _options.WillTopic = willTopic;


### PR DESCRIPTION
Warning was always logged while the text states it would throw a `MqttConnectingFailedException` exception.